### PR TITLE
deploy - don't push to latest

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,21 +4,15 @@ echo $VERSION
 
 # us-east-1
 eval $(docker run --rm -i -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY quay.io/keboola/aws-cli ecr get-login --region us-east-1)
-docker tag logspout:$VERSION 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:latest
-docker push 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:latest
-docker tag logspout:$VERSION 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
-docker push 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
+docker tag logspout:$VERSION 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:$TRAVIS_TAG
+docker push 147946154733.dkr.ecr.us-east-1.amazonaws.com/keboola/logspout:$TRAVIS_TAG
 
 # eu-central-1
 eval $(docker run --rm -i -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY quay.io/keboola/aws-cli ecr get-login --region eu-central-1)
-docker tag logspout:$VERSION 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:latest
-docker push 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:latest
-docker tag logspout:$VERSION 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
-docker push 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
+docker tag logspout:$VERSION 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:$TRAVIS_TAG
+docker push 147946154733.dkr.ecr.eu-central-1.amazonaws.com/keboola/logspout:$TRAVIS_TAG
 
 # ap-southeast-2
 eval $(docker run --rm -i -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY quay.io/keboola/aws-cli ecr get-login --region ap-southeast-2)
-docker tag logspout:$VERSION 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout:latest
-docker push 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout
-docker tag logspout:$VERSION 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
-docker push 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout:$TRAVIS_COMMIT
+docker tag logspout:$VERSION 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout:$TRAVIS_TAG
+docker push 147946154733.dkr.ecr.ap-southeast-2.amazonaws.com/keboola/logspout:$TRAVIS_TAG


### PR DESCRIPTION
Pushne jako aktuální tag místo update latest. V [provisioningu instance](https://github.com/keboola/connection/blob/0528367170d83f4ae5ba566e7b4a4e51327ae65a/provisioning/ecs.json#L7) pak můžeme otestovat konkrétní tag.